### PR TITLE
fix: public endpoint

### DIFF
--- a/01-Authorization/app/views.py
+++ b/01-Authorization/app/views.py
@@ -8,7 +8,7 @@ def public(request: HttpRequest()) -> JsonResponse:
     return JsonResponse(
         data={
             "message": "Hello from a public endpoint! You don't need to be authenticated to see this.",
-            "token": token.dict(),
+            "token": token.dict() if token is not None else None,
         }
     )
 


### PR DESCRIPTION
The token can be None in public endpoint and hence token.dict() will throw error.